### PR TITLE
Remove `Markdown` view `@State` property

### DIFF
--- a/Sources/MarkdownUI/Extensions/DefaultImageProvider.swift
+++ b/Sources/MarkdownUI/Extensions/DefaultImageProvider.swift
@@ -12,7 +12,6 @@ public struct DefaultImageProvider: ImageProvider {
 
   public func makeImage(url: URL?) -> some View {
     DefaultImageView(url: url, urlSession: self.urlSession)
-      .id(url)
   }
 }
 

--- a/Sources/MarkdownUI/Extensions/DefaultImageView/DefaultImageView.swift
+++ b/Sources/MarkdownUI/Extensions/DefaultImageView/DefaultImageView.swift
@@ -11,7 +11,7 @@ struct DefaultImageView: View {
     case .notRequested, .loading, .failure:
       Color.clear
         .frame(width: 0, height: 0)
-        .task {
+        .task(id: self.url) {
           await self.viewModel.task(url: self.url, urlSession: self.urlSession)
         }
     case .success(let image, let size):


### PR DESCRIPTION
Remove the `Markdown` view `@State` property used to cache the parsed Markdown contents. This optimization was useless and didn't play well with SwiftUI's `ImageRenderer`, as stated in #190.