### PR TITLE
Font+FontProperties: Avoid losing explicit precision

### DIFF
--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
@@ -3,7 +3,7 @@ import SwiftUI
 extension Font {
   static func withProperties(_ fontProperties: FontProperties) -> Font {
     var font: Font
-    let size = round(fontProperties.size * fontProperties.scale)
+    let size = fontProperties.size * fontProperties.scale
 
     switch fontProperties.family {
     case .system(let design):


### PR DESCRIPTION
Explicit fractional point sizes were being silently rounded. I assume it could have been desired behavior, only it's not expected nor communicated, and we cannot opt-out otherwise.