### PR TITLE
Provide access to the language and the content of a code block from the body of the style.

### DIFF
--- a/Sources/MarkdownUI/Theme/BlockStyle/CodeBlockConfiguration.swift
+++ b/Sources/MarkdownUI/Theme/BlockStyle/CodeBlockConfiguration.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// The properties of a Markdown code block.
+///
+/// The theme ``Theme/codeBlock`` block style receives a `CodeBlockConfiguration`
+/// input in its `body` closure.
+public struct CodeBlockConfiguration {
+  /// A type-erased view of a Markdown code block.
+  public struct Label: View {
+    init<L: View>(_ label: L) {
+      self.body = AnyView(label)
+    }
+
+    public let body: AnyView
+  }
+
+  /// The code block language, if present.
+  public let language: String?
+
+  /// The code block contents.
+  public let content: String
+
+  /// The code block view.
+  public let label: Label
+}

--- a/Sources/MarkdownUI/Theme/Theme+Basic.swift
+++ b/Sources/MarkdownUI/Theme/Theme+Basic.swift
@@ -80,9 +80,9 @@ extension Theme {
         .relativePadding(.leading, length: .em(2))
         .relativePadding(.trailing, length: .em(1))
     }
-    .codeBlock { label in
+    .codeBlock { configuration in
       ScrollView(.horizontal) {
-        label
+        configuration.label
           .relativeLineSpacing(.em(0.15))
           .relativePadding(.leading, length: .rem(1))
           .markdownTextStyle {

--- a/Sources/MarkdownUI/Theme/Theme+DocC.swift
+++ b/Sources/MarkdownUI/Theme/Theme+DocC.swift
@@ -92,9 +92,9 @@ extension Theme {
         }
         .markdownMargin(top: .em(1.6), bottom: .zero)
     }
-    .codeBlock { label in
+    .codeBlock { configuration in
       ScrollView(.horizontal) {
-        label
+        configuration.label
           .relativeLineSpacing(.em(0.333335))
           .markdownTextStyle {
             FontFamilyVariant(.monospaced)

--- a/Sources/MarkdownUI/Theme/Theme+GitHub.swift
+++ b/Sources/MarkdownUI/Theme/Theme+GitHub.swift
@@ -109,9 +109,9 @@ extension Theme {
       }
       .fixedSize(horizontal: false, vertical: true)
     }
-    .codeBlock { label in
+    .codeBlock { configuration in
       ScrollView(.horizontal) {
-        label
+        configuration.label
           .relativeLineSpacing(.em(0.225))
           .markdownTextStyle {
             FontFamilyVariant(.monospaced)

--- a/Sources/MarkdownUI/Theme/Theme.swift
+++ b/Sources/MarkdownUI/Theme/Theme.swift
@@ -162,7 +162,7 @@ public struct Theme {
   public var blockquote = BlockStyle()
 
   /// The code block style.
-  public var codeBlock = BlockStyle()
+  public var codeBlock: BlockStyle<CodeBlockConfiguration> = BlockStyle { $0.label }
 
   /// The image style.
   public var image = BlockStyle()
@@ -186,14 +186,10 @@ public struct Theme {
   public var table = BlockStyle()
 
   /// The table cell style.
-  public var tableCell: BlockStyle<TableCellConfiguration> = BlockStyle { configuration in
-    configuration.label
-  }
+  public var tableCell: BlockStyle<TableCellConfiguration> = BlockStyle { $0.label }
 
   /// The thematic break style.
-  public var thematicBreak = BlockStyle {
-    Divider()
-  }
+  public var thematicBreak = BlockStyle { Divider() }
 
   /// Creates a theme with default text styles.
   public init() {}
@@ -333,7 +329,7 @@ extension Theme {
   /// Adds a code block style to the theme.
   /// - Parameter body: A view builder that returns a customized code block.
   public func codeBlock<Body: View>(
-    @ViewBuilder body: @escaping (_ label: BlockConfiguration.Label) -> Body
+    @ViewBuilder body: @escaping (_ configuration: CodeBlockConfiguration) -> Body
   ) -> Theme {
     var theme = self
     theme.codeBlock = .init(body: body)

--- a/Sources/MarkdownUI/Utility/Deprecations.swift
+++ b/Sources/MarkdownUI/Utility/Deprecations.swift
@@ -1,5 +1,35 @@
 import SwiftUI
 
+// MARK: - Deprecated after 2.0.2:
+
+extension View {
+  @available(*, deprecated, message: "Use the version of this function that takes a closure receiving a generic 'Configuration' value.")
+  public func markdownBlockStyle<Body: View>(
+    _ keyPath: WritableKeyPath<Theme, BlockStyle<CodeBlockConfiguration>>,
+    @ViewBuilder body: @escaping (_ label: BlockConfiguration.Label) -> Body
+  ) -> some View {
+    self.environment(
+      (\EnvironmentValues.theme).appending(path: keyPath),
+      .init { configuration in
+        body(.init(configuration.label))
+      }
+    )
+  }
+}
+
+extension Theme {
+  @available(*, deprecated, message: "Use the version of this function that takes a closure receiving a 'CodeBlockConfiguration' value.")
+  public func codeBlock<Body: View>(
+    @ViewBuilder body: @escaping (_ label: BlockConfiguration.Label) -> Body
+  ) -> Theme {
+    var theme = self
+    theme.codeBlock = .init { configuration in
+      body(.init(configuration.label))
+    }
+    return theme
+  }
+}
+
 // MARK: - Unavailable after 1.1.1:
 
 extension Heading {

--- a/Sources/MarkdownUI/Views/Blocks/BlockNode+View.swift
+++ b/Sources/MarkdownUI/Views/Blocks/BlockNode+View.swift
@@ -12,7 +12,7 @@ extension BlockNode: View {
     case .taskList(let isTight, let items):
       ApplyBlockStyle(\.list, to: TaskListView(isTight: isTight, items: items))
     case .codeBlock(let fenceInfo, let content):
-      ApplyBlockStyle(\.codeBlock, to: CodeBlockView(fenceInfo: fenceInfo, content: content))
+      CodeBlockView(fenceInfo: fenceInfo, content: content)
     case .htmlBlock(let content):
       ApplyBlockStyle(\.paragraph, to: HTMLBlockView(content: content))
     case .paragraph(let content):

--- a/Sources/MarkdownUI/Views/Blocks/CodeBlockView.swift
+++ b/Sources/MarkdownUI/Views/Blocks/CodeBlockView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct CodeBlockView: View {
+  @Environment(\.theme.codeBlock) private var codeBlock
   @Environment(\.codeSyntaxHighlighter) private var codeSyntaxHighlighter
 
   private let fenceInfo: String?
@@ -12,6 +13,16 @@ struct CodeBlockView: View {
   }
 
   var body: some View {
+    codeBlock.makeBody(
+      configuration: .init(
+        language: self.fenceInfo,
+        content: self.content,
+        label: .init(self.label)
+      )
+    )
+  }
+
+  private var label: some View {
     self.codeSyntaxHighlighter.highlightCode(self.content, language: self.fenceInfo)
       .textStyleFont()
   }


### PR DESCRIPTION
This feature has been discussed in #201 