### PR TITLE
Apply the current text style foreground color to code blocks

### DIFF
--- a/Sources/MarkdownUI/Views/Blocks/CodeBlockView.swift
+++ b/Sources/MarkdownUI/Views/Blocks/CodeBlockView.swift
@@ -25,5 +25,6 @@ struct CodeBlockView: View {
   private var label: some View {
     self.codeSyntaxHighlighter.highlightCode(self.content, language: self.fenceInfo)
       .textStyleFont()
+      .textStyleForegroundColor()
   }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+TextStyle.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+TextStyle.swift
@@ -21,6 +21,12 @@ extension View {
     }
   }
 
+  func textStyleForegroundColor() -> some View {
+    TextStyleAttributesReader { attributes in
+      self.foregroundColor(attributes.foregroundColor)
+    }
+  }
+
   func textStyle(_ textStyle: TextStyle) -> some View {
     self.transformEnvironment(\.textStyle) {
       $0 = $0.appending(textStyle)


### PR DESCRIPTION
Fix #226 