### PR TITLE
visionOS support (new method)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,7 @@ let package = Package(
     .macOS(.v12),
     .iOS(.v15),
     .tvOS(.v15),
-    .watchOS(.v8),
-    .custom("visionOS", versionString: "1.0")
+    .watchOS(.v8)
   ],
   products: [
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     .iOS(.v15),
     .tvOS(.v15),
     .watchOS(.v8),
+    .custom("visionOS", versionString: "1.0")
   ],
   products: [
     .library(

--- a/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
@@ -44,7 +44,7 @@ public struct AssetImageProvider: ImageProvider {
       } else {
         return NSImage(named: self.name(url))
       }
-    #elseif os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
       return UIImage(named: self.name(url), in: self.bundle, with: nil)
     #endif
   }

--- a/Sources/MarkdownUI/Extensibility/DefaultImageView/DefaultImageLoader.swift
+++ b/Sources/MarkdownUI/Extensibility/DefaultImageView/DefaultImageLoader.swift
@@ -32,7 +32,7 @@ final class DefaultImageLoader {
 
 extension PlatformImage {
   fileprivate static func decode(from data: Data) -> PlatformImage? {
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #if canImport(UIKit)
       guard let image = UIImage(data: data) else {
         return nil
       }

--- a/Sources/MarkdownUI/Extensibility/Image+PlatformImage.swift
+++ b/Sources/MarkdownUI/Extensibility/Image+PlatformImage.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(UIKit)
   typealias PlatformImage = UIImage
 #elseif os(macOS)
   typealias PlatformImage = NSImage
@@ -8,7 +8,7 @@ import SwiftUI
 
 extension Image {
   init(platformImage: PlatformImage) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #if canImport(UIKit)
       self.init(uiImage: platformImage)
     #elseif os(macOS)
       self.init(nsImage: platformImage)

--- a/Sources/MarkdownUI/Utility/Color+RGBA.swift
+++ b/Sources/MarkdownUI/Utility/Color+RGBA.swift
@@ -27,7 +27,9 @@ extension Color {
           }
         }
       )
-    #elseif os(iOS) || os(tvOS)
+    #elseif os(watchOS)
+      self = dark()
+    #elseif canImport(UIKit)
       self.init(
         uiColor: .init { traitCollection in
           switch traitCollection.userInterfaceStyle {
@@ -40,8 +42,6 @@ extension Color {
           }
         }
       )
-    #elseif os(watchOS)
-      self = dark()
     #endif
   }
 }


### PR DESCRIPTION
Since the project is using the UIKit most of the times (iOS, watchOS, tvOS, visionOS, mac catalyst) instead of specifying os check types, we should use `#if canImport(UIKit)`.
So in future if apple added any type of device (such as glasses 😁) and that device can use UIKit, we don't have to change anything (even we don't have to specify any swift version check).

Also this can be removed from `package.swift` if there is any problem with Xcode 14 (couldn't confirm that):
```
.custom("visionOS", versionString: "1.0")
```
Cheers