### PR TITLE
Xcode 15

### DIFF
--- a/Sources/MarkdownUI/Extensibility/Image+PlatformImage.swift
+++ b/Sources/MarkdownUI/Extensibility/Image+PlatformImage.swift
@@ -4,6 +4,9 @@ import SwiftUI
   typealias PlatformImage = UIImage
 #elseif os(macOS)
   typealias PlatformImage = NSImage
+  extension PlatformImage: @unchecked Sendable {
+    
+  }
 #endif
 
 extension Image {


### PR DESCRIPTION
Fix warning

```
Non-sendable type 'PlatformImage' (aka 'NSImage') returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary
```