### PR TITLE
add `FontWidth` to support `width` support introduced in iOS 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
   name: "swift-markdown-ui",
   platforms: [
-    .macOS(.v12),
-    .iOS(.v15),
-    .tvOS(.v15),
-    .watchOS(.v8),
+    .macOS(.v13),
+    .iOS(.v16),
+    .tvOS(.v16),
+    .watchOS(.v9)
   ],
   products: [
     .library(

--- a/Sources/MarkdownUI/Documentation.docc/MarkdownUI.md
+++ b/Sources/MarkdownUI/Documentation.docc/MarkdownUI.md
@@ -38,6 +38,7 @@ You can use the built-in themes, create your own or override specific text and b
 - ``FontSize``
 - ``FontStyle``
 - ``FontWeight``
+- ``FontWidth``
 - ``StrikethroughStyle``
 - ``UnderlineStyle``
 - ``FontFamilyVariant``

--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
@@ -37,8 +37,12 @@ extension Font {
       font = font.monospacedDigit()
     }
 
-    if fontProperties.weight != .regular {
+    if fontProperties.weight != FontProperties.defaultWeight {
       font = font.weight(fontProperties.weight)
+    }
+
+    if fontProperties.width != FontProperties.defaultWidth {
+      font = font.width(fontProperties.width)
     }
 
     switch fontProperties.style {

--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/FontProperties.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/FontProperties.swift
@@ -77,6 +77,8 @@ public struct FontProperties: Hashable {
     #endif
   }
 
+  public static var defaultWidth: Font.Width = .standard
+
   /// The font family.
   public var family: Family = .system()
 
@@ -94,6 +96,9 @@ public struct FontProperties: Hashable {
 
   /// The font weight.
   public var weight: Font.Weight = Self.defaultWeight
+
+  /// The font width.
+  public var width: Font.Width = Self.defaultWidth
 
   /// The font size.
   public var size: CGFloat = Self.defaultSize
@@ -114,6 +119,7 @@ public struct FontProperties: Hashable {
   ///   - digitVariant: The font digit variant.
   ///   - style: The font style.
   ///   - weight: The font weight.
+  ///   - width: The font width
   ///   - size: The font size.
   ///   - scale: The font scale.
   public init(
@@ -123,6 +129,7 @@ public struct FontProperties: Hashable {
     digitVariant: FontProperties.DigitVariant = .normal,
     style: FontProperties.Style = .normal,
     weight: Font.Weight = Self.defaultWeight,
+    width: Font.Width = Self.defaultWidth,
     size: CGFloat = Self.defaultSize,
     scale: CGFloat = 1
   ) {
@@ -132,6 +139,7 @@ public struct FontProperties: Hashable {
     self.digitVariant = digitVariant
     self.style = style
     self.weight = weight
+    self.width = width
     self.size = size
     self.scale = scale
   }

--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/FontWidth.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/FontWidth.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// A text style that adjusts the font width.
+public struct FontWidth: TextStyle {
+  private let width: Font.Width
+
+  /// Creates a font width text style.
+  /// - Parameter width: The font width.
+  public init(_ width: Font.Width) {
+    self.width = width
+  }
+
+  public func _collectAttributes(in attributes: inout AttributeContainer) {
+    attributes.fontProperties?.width = self.width
+  }
+}


### PR DESCRIPTION
- requires updating `Package.swift` to use `swift-tools-version:5.7`
- requires setting minimum supported OS with `.width` support
- minimal non-code `.md` updates