### PR TITLE
refactor: prefer checking module availability over the os check

### DIFF
--- a/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
@@ -38,7 +38,7 @@ public struct AssetImageProvider: ImageProvider {
   }
 
   private func image(url: URL) -> PlatformImage? {
-    #if os(macOS)
+    #if canImport(AppKit)
       if let bundle, bundle != .main {
         return bundle.image(forResource: self.name(url))
       } else {
@@ -61,7 +61,7 @@ extension ImageProvider where Self == AssetImageProvider {
 
 #if canImport(UIKit)
   private typealias PlatformImage = UIImage
-#elseif os(macOS)
+#elseif canImport(AppKit)
   private typealias PlatformImage = NSImage
 #endif
 
@@ -69,7 +69,7 @@ extension Image {
   fileprivate init(platformImage: PlatformImage) {
     #if canImport(UIKit)
       self.init(uiImage: platformImage)
-    #elseif os(macOS)
+    #elseif canImport(AppKit)
       self.init(nsImage: platformImage)
     #endif
   }

--- a/Sources/MarkdownUI/Utility/Color+RGBA.swift
+++ b/Sources/MarkdownUI/Utility/Color+RGBA.swift
@@ -17,7 +17,7 @@ extension Color {
   ///   - light: The light appearance color value.
   ///   - dark: The dark appearance color value.
   public init(light: @escaping @autoclosure () -> Color, dark: @escaping @autoclosure () -> Color) {
-    #if os(macOS)
+    #if canImport(AppKit)
       self.init(
         nsColor: .init(name: nil) { appearance in
           if appearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua {


### PR DESCRIPTION
In addition to [this merged PR](https://github.com/gonzalezreal/swift-markdown-ui/pull/252), using `canImport()` is an improvement because it lets you focus on what functionality you want rather than what operating system.

So, for example, if `UIKit` becomes available on `macOS` tomorrow you won’t need to change your code to use it. 

P.S.: Something similar happened for the visionOS already.