### PR TITLE
Make blocknodes public

### DIFF
--- a/Sources/MarkdownUI/DSL/Blocks/MarkdownContent.swift
+++ b/Sources/MarkdownUI/DSL/Blocks/MarkdownContent.swift
@@ -71,7 +71,7 @@ public struct MarkdownContent: Equatable, MarkdownContentProtocol {
   }
 
   public var _markdownContent: MarkdownContent { self }
-  let blocks: [BlockNode]
+  public let blocks: [BlockNode]
 
   init(blocks: [BlockNode] = []) {
     self.blocks = blocks

--- a/Sources/MarkdownUI/DSL/Blocks/MarkdownContent.swift
+++ b/Sources/MarkdownUI/DSL/Blocks/MarkdownContent.swift
@@ -73,11 +73,11 @@ public struct MarkdownContent: Equatable, MarkdownContentProtocol {
   public var _markdownContent: MarkdownContent { self }
   public let blocks: [BlockNode]
 
-  init(blocks: [BlockNode] = []) {
+  public init(blocks: [BlockNode] = []) {
     self.blocks = blocks
   }
 
-  init(block: BlockNode) {
+  public init(block: BlockNode) {
     self.init(blocks: [block])
   }
 

--- a/Sources/MarkdownUI/Parser/BlockNode.swift
+++ b/Sources/MarkdownUI/Parser/BlockNode.swift
@@ -36,12 +36,12 @@ extension BlockNode {
 }
 
 public struct RawListItem: Hashable {
-  let children: [BlockNode]
+  public let children: [BlockNode]
 }
 
 public struct RawTaskListItem: Hashable {
-  let isCompleted: Bool
-  let children: [BlockNode]
+  public let isCompleted: Bool
+  public let children: [BlockNode]
 }
 
 public enum RawTableColumnAlignment: Character {
@@ -52,9 +52,9 @@ public enum RawTableColumnAlignment: Character {
 }
 
 public struct RawTableRow: Hashable {
-  let cells: [RawTableCell]
+  public let cells: [RawTableCell]
 }
 
 public struct RawTableCell: Hashable {
-  let content: [InlineNode]
+  public let content: [InlineNode]
 }

--- a/Sources/MarkdownUI/Parser/BlockNode.swift
+++ b/Sources/MarkdownUI/Parser/BlockNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BlockNode: Hashable {
+public enum BlockNode: Hashable {
   case blockquote(children: [BlockNode])
   case bulletedList(isTight: Bool, items: [RawListItem])
   case numberedList(isTight: Bool, start: Int, items: [RawListItem])
@@ -35,26 +35,26 @@ extension BlockNode {
   }
 }
 
-struct RawListItem: Hashable {
+public struct RawListItem: Hashable {
   let children: [BlockNode]
 }
 
-struct RawTaskListItem: Hashable {
+public struct RawTaskListItem: Hashable {
   let isCompleted: Bool
   let children: [BlockNode]
 }
 
-enum RawTableColumnAlignment: Character {
+public enum RawTableColumnAlignment: Character {
   case none = "\0"
   case left = "l"
   case center = "c"
   case right = "r"
 }
 
-struct RawTableRow: Hashable {
+public struct RawTableRow: Hashable {
   let cells: [RawTableCell]
 }
 
-struct RawTableCell: Hashable {
+public struct RawTableCell: Hashable {
   let content: [InlineNode]
 }

--- a/Sources/MarkdownUI/Parser/InlineNode.swift
+++ b/Sources/MarkdownUI/Parser/InlineNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum InlineNode: Hashable {
+public enum InlineNode: Hashable {
   case text(String)
   case softBreak
   case lineBreak

--- a/Sources/MarkdownUI/Views/Blocks/BlockNode+View.swift
+++ b/Sources/MarkdownUI/Views/Blocks/BlockNode+View.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension BlockNode: View {
-  var body: some View {
+  public var body: some View {
     switch self {
     case .blockquote(let children):
       BlockquoteView(children: children)


### PR DESCRIPTION
Hey @gonzalezreal ,  I am loving your awesome library! Thanks for sharing it.

I have a use-case where I want to use the MarkdownContent parser and inspect the blocks. I want the app to behave differently if the markdown contains a codeblock, so I want to do something like:

```
let markdown = MarkdownContent(text)
if let codeBlock = markdown.blocks.first(...) {
   // do this
}
```

The problem is that BlockNode is not public, so I can't access it. I'm creating this fork as a workaround, but opening a PR in case you think it's worth exposing.
