### PR TITLE
fix macCatalyst build failure: re-order `#if canImport(UIKit)`

### DIFF
--- a/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
@@ -38,14 +38,14 @@ public struct AssetImageProvider: ImageProvider {
   }
 
   private func image(url: URL) -> PlatformImage? {
-    #if canImport(AppKit)
+    #if canImport(UIKit)
+      return UIImage(named: self.name(url), in: self.bundle, with: nil)
+    #elseif canImport(AppKit)
       if let bundle, bundle != .main {
         return bundle.image(forResource: self.name(url))
       } else {
         return NSImage(named: self.name(url))
       }
-    #elseif canImport(UIKit)
-      return UIImage(named: self.name(url), in: self.bundle, with: nil)
     #endif
   }
 }

--- a/Sources/MarkdownUI/Utility/Color+RGBA.swift
+++ b/Sources/MarkdownUI/Utility/Color+RGBA.swift
@@ -17,17 +17,7 @@ extension Color {
   ///   - light: The light appearance color value.
   ///   - dark: The dark appearance color value.
   public init(light: @escaping @autoclosure () -> Color, dark: @escaping @autoclosure () -> Color) {
-    #if canImport(AppKit)
-      self.init(
-        nsColor: .init(name: nil) { appearance in
-          if appearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua {
-            return NSColor(light())
-          } else {
-            return NSColor(dark())
-          }
-        }
-      )
-    #elseif os(watchOS)
+    #if os(watchOS)
       self = dark()
     #elseif canImport(UIKit)
       self.init(
@@ -39,6 +29,16 @@ extension Color {
             return UIColor(dark())
           @unknown default:
             return UIColor(light())
+          }
+        }
+      )
+    #elseif canImport(AppKit)
+      self.init(
+        nsColor: .init(name: nil) { appearance in
+          if appearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua {
+            return NSColor(light())
+          } else {
+            return NSColor(dark())
           }
         }
       )


### PR DESCRIPTION
by placing `#if canImport(UIKit)` first, it means that building for `#if targetEnvironment(macCatalyst)` doesn't fail attempting to use and link in `AppKit` things (since `macCatalyst` apps can link both `UIKit` and `AppKit`