### PR TITLE
Fix bullets in visionOS

### DIFF
--- a/Sources/MarkdownUI/Views/Blocks/ListItemView.swift
+++ b/Sources/MarkdownUI/Views/Blocks/ListItemView.swift
@@ -40,5 +40,30 @@ struct ListItemView: View {
         .readWidth(column: 0)
         .frame(width: self.markerWidth, alignment: .trailing)
     }
+    #if os(visionOS)
+    .labelStyle(BulletItemStyle())
+    #endif
   }
+}
+
+
+extension VerticalAlignment {
+   private enum CenterOfFirstLine: AlignmentID {
+      static func defaultValue(in context: ViewDimensions) -> CGFloat {
+         let heightAfterFirstLine = context[.lastTextBaseline] - context[.firstTextBaseline]
+         let heightOfFirstLine = context.height - heightAfterFirstLine
+         return heightOfFirstLine / 2
+      }
+   }
+   static let centerOfFirstLine = Self(CenterOfFirstLine.self)
+}
+
+
+struct BulletItemStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .centerOfFirstLine, spacing: 4) {
+            configuration.icon
+            configuration.title
+        }
+    }
 }


### PR DESCRIPTION
Label does not align the icon with the center of the first line like on iOS. This happens in the simulator so I guess it will happen on ht actual device.

Before the fix:
![Simulator Screenshot - Apple Vision Pro - 2024-04-13 at 19 41 43](https://github.com/gonzalezreal/swift-markdown-ui/assets/76906/5a00ec07-677c-4691-ad94-2723317be4fa)

After the fix:
![Simulator Screenshot - Apple Vision Pro - 2024-04-13 at 19 45 12](https://github.com/gonzalezreal/swift-markdown-ui/assets/76906/cf7d2af3-b618-491e-a4ec-b8188cad9354)

This fix applies, only on visionOS, a custom `LabelStyle`  to list items that align the bullet to the center of the first line.