### PR TITLE
Fixing dynamic type for custom fonts

### DIFF
--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/Font+FontProperties.swift
@@ -9,7 +9,7 @@ extension Font {
     case .system(let design):
       font = .system(size: size, design: design)
     case .custom(let name):
-      font = .custom(name, size: size)
+      font = .custom(name, fixedSize: size)
     }
 
     switch fontProperties.familyVariant {


### PR DESCRIPTION
Right now it seems the library accounts for dynamic type twice when using custom fonts.

This is because it is using the `@ScaledMetric` for dynamic size, as well as `custom(_ name: String, size: CGFloat)` constructor for Font. The docs for that one say

```
    /// Create a custom font with the given `name` and `size` that scales with
    /// the body text style.
```

Which means its scales it again.

It seems like the easiest fix is just calling the other constructor for custom fonts which has a `fixedSize` parameter. It appears that all the versions required in Package.swift support that constructor.