### PR TITLE
Fix "error: circular reference" in Xcode 16.0 beta (16A5171c).

### DIFF
--- a/Sources/MarkdownUI/DSL/Inlines/Emphasis.swift
+++ b/Sources/MarkdownUI/DSL/Inlines/Emphasis.swift
@@ -3,7 +3,7 @@ import Foundation
 /// An emphasized text in a Markdown content block.
 public struct Emphasis: InlineContentProtocol {
   public var _inlineContent: InlineContent {
-    .init(inlines: [.emphasis(children: self.content.inlines)])
+    .init(inlines: [.emphasis(self.content.inlines)])
   }
 
   private let content: InlineContent

--- a/Sources/MarkdownUI/DSL/Inlines/InlineImage.swift
+++ b/Sources/MarkdownUI/DSL/Inlines/InlineImage.swift
@@ -26,7 +26,7 @@ import Foundation
 /// ![](InlineImage)
 public struct InlineImage: InlineContentProtocol {
   public var _inlineContent: InlineContent {
-    .init(inlines: [.image(source: self.source, children: self.content.inlines)])
+    .init(inlines: [.image(source: self.source, self.content.inlines)])
   }
 
   private let source: String

--- a/Sources/MarkdownUI/DSL/Inlines/InlineLink.swift
+++ b/Sources/MarkdownUI/DSL/Inlines/InlineLink.swift
@@ -30,7 +30,7 @@ import Foundation
 /// ```
 public struct InlineLink: InlineContentProtocol {
   public var _inlineContent: InlineContent {
-    .init(inlines: [.link(destination: self.destination, children: self.content.inlines)])
+    .init(inlines: [.link(destination: self.destination, self.content.inlines)])
   }
 
   private let destination: String

--- a/Sources/MarkdownUI/DSL/Inlines/Strikethrough.swift
+++ b/Sources/MarkdownUI/DSL/Inlines/Strikethrough.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A deleted or redacted text in a Markdown content block.
 public struct Strikethrough: InlineContentProtocol {
   public var _inlineContent: InlineContent {
-    .init(inlines: [.strikethrough(children: self.content.inlines)])
+    .init(inlines: [.strikethrough(self.content.inlines)])
   }
 
   private let content: InlineContent

--- a/Sources/MarkdownUI/DSL/Inlines/Strong.swift
+++ b/Sources/MarkdownUI/DSL/Inlines/Strong.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A strong text in a Markdown content block.
 public struct Strong: InlineContentProtocol {
   public var _inlineContent: InlineContent {
-    .init(inlines: [.strong(children: self.content.inlines)])
+    .init(inlines: [.strong(self.content.inlines)])
   }
 
   private let content: InlineContent

--- a/Sources/MarkdownUI/Parser/InlineNode.swift
+++ b/Sources/MarkdownUI/Parser/InlineNode.swift
@@ -6,11 +6,11 @@ enum InlineNode: Hashable {
   case lineBreak
   case code(String)
   case html(String)
-  case emphasis(children: [InlineNode])
-  case strong(children: [InlineNode])
-  case strikethrough(children: [InlineNode])
-  case link(destination: String, children: [InlineNode])
-  case image(source: String, children: [InlineNode])
+  case emphasis([InlineNode])
+  case strong([InlineNode])
+  case strikethrough([InlineNode])
+  case link(destination: String, [InlineNode])
+  case image(source: String, [InlineNode])
 }
 
 extension InlineNode {
@@ -35,15 +35,15 @@ extension InlineNode {
     set {
       switch self {
       case .emphasis:
-        self = .emphasis(children: newValue)
+        self = .emphasis(newValue)
       case .strong:
-        self = .strong(children: newValue)
+        self = .strong(newValue)
       case .strikethrough:
-        self = .strikethrough(children: newValue)
+        self = .strikethrough(newValue)
       case .link(let destination, _):
-        self = .link(destination: destination, children: newValue)
+        self = .link(destination: destination, newValue)
       case .image(let source, _):
-        self = .image(source: source, children: newValue)
+        self = .image(source: source, newValue)
       default:
         break
       }

--- a/Sources/MarkdownUI/Parser/MarkdownParser.swift
+++ b/Sources/MarkdownUI/Parser/MarkdownParser.swift
@@ -134,20 +134,20 @@ extension InlineNode {
     case .html:
       self = .html(unsafeNode.literal ?? "")
     case .emphasis:
-      self = .emphasis(children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
+      self = .emphasis(unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
     case .strong:
-      self = .strong(children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
+      self = .strong(unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
     case .strikethrough:
-      self = .strikethrough(children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
+      self = .strikethrough(unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
     case .link:
       self = .link(
         destination: unsafeNode.url ?? "",
-        children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:))
+        unsafeNode.children.compactMap(InlineNode.init(unsafeNode:))
       )
     case .image:
       self = .image(
         source: unsafeNode.url ?? "",
-        children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:))
+        unsafeNode.children.compactMap(InlineNode.init(unsafeNode:))
       )
     default:
       assertionFailure("Unhandled node type '\(unsafeNode.nodeType)' in InlineNode.")

--- a/Sources/MarkdownUI/Views/Inlines/ImageView.swift
+++ b/Sources/MarkdownUI/Views/Inlines/ImageView.swift
@@ -32,13 +32,13 @@ struct ImageView: View {
         content: [
           .link(
             destination: destination,
-            children: [.image(source: self.data.source, children: [.text(self.data.alt)])]
+            [.image(source: self.data.source, [.text(self.data.alt)])]
           )
         ]
       )
     } else {
       return .paragraph(
-        content: [.image(source: self.data.source, children: [.text(self.data.alt)])]
+        content: [.image(source: self.data.source, [.text(self.data.alt)])]
       )
     }
   }


### PR DESCRIPTION
FB13830058 tracks upstream resolution of this, as this seems to be a Swift compiler bug.

Fixes https://github.com/gonzalezreal/swift-markdown-ui/issues/323