### PR TITLE
Table border style now has multiple colors and selectors

### DIFF
--- a/Sources/MarkdownUI/Theme/BlockStyle/TableBorderStyle.swift
+++ b/Sources/MarkdownUI/Theme/BlockStyle/TableBorderStyle.swift
@@ -31,14 +31,36 @@ import SwiftUI
 ///
 /// ![](CustomTableBorders)
 public struct TableBorderStyle {
-  /// The visible table borders.
-  public var visibleBorders: TableBorderSelector
+  public struct Border {
+    /// The visible table borders.
+    public var visibleBorders: TableBorderSelector
 
-  /// The table border color.
-  public var color: Color
+    /// The table border color.
+    public var color: Color
+
+    public init(visibleBorders: TableBorderSelector, color: Color) {
+      self.visibleBorders = visibleBorders
+      self.color = color
+    }
+  }
+
+  /// The table's list of borders
+  public var borders: [Border]
 
   /// The table border stroke style.
   public var strokeStyle: StrokeStyle
+
+  /// Creates a table border style with the given borders and stroke style.
+  /// - Parameters:
+  ///   - borders: The visible table borders.
+  ///   - strokeStyle: The table border stroke style.
+  public init(
+    _ borders: [Border],
+    strokeStyle: StrokeStyle
+  ) {
+    self.borders = borders
+    self.strokeStyle = strokeStyle
+  }
 
   /// Creates a table border style with the given visible borders, color, and stroke style.
   /// - Parameters:
@@ -50,8 +72,7 @@ public struct TableBorderStyle {
     color: Color,
     strokeStyle: StrokeStyle
   ) {
-    self.visibleBorders = visibleBorders
-    self.color = color
+    self.borders = [.init(visibleBorders: visibleBorders, color: color)]
     self.strokeStyle = strokeStyle
   }
 

--- a/Sources/MarkdownUI/Views/Blocks/TableBorderSelector.swift
+++ b/Sources/MarkdownUI/Views/Blocks/TableBorderSelector.swift
@@ -57,6 +57,78 @@ extension TableBorderSelector {
     }
   }
 
+  /// A table border selector that selects the inside borders of a table's first row.
+  public static var insideBordersFirstRow: TableBorderSelector {
+    TableBorderSelector { tableBounds, borderWidth in
+      guard tableBounds.rowCount > 0 else { return [] }
+      let firstRowBounds = tableBounds.bounds(forRow: 0)
+
+      return [
+        CGRect(
+          origin: .init(x: firstRowBounds.minX, y: firstRowBounds.maxY - borderWidth),
+          size: .init(width: firstRowBounds.width, height: borderWidth)
+        )
+      ] + (0..<tableBounds.columnCount - 1)
+        .map {
+          tableBounds.bounds(forColumn: $0)
+            .insetBy(dx: -borderWidth, dy: -borderWidth)
+        }
+        .map {
+          CGRect(
+            origin: .init(x: $0.maxX - borderWidth, y: firstRowBounds.minY),
+            size: .init(width: borderWidth, height: firstRowBounds.height)
+          )
+        }
+    }
+  }
+
+  /// A table border selector that selects the inside borders of a table, except for the first row.
+  public static var insideBordersExceptFirstRow: TableBorderSelector {
+    TableBorderSelector { tableBounds, borderWidth in
+      Self.insideHorizontalBordersExceptFirstRow.rectangles(tableBounds, borderWidth)
+        + Self.insideVerticalBordersExceptFirstRow.rectangles(tableBounds, borderWidth)
+    }
+  }
+
+  /// A table border selector that selects the inside horizontal borders of a table, except for the first row.
+  public static var insideHorizontalBordersExceptFirstRow: TableBorderSelector {
+    TableBorderSelector { tableBounds, borderWidth in
+      let rowCount = tableBounds.rowCount
+      guard rowCount > 1 else { return [] }
+      return (1..<rowCount - 1)
+        .map {
+          tableBounds.bounds(forRow: $0)
+            .insetBy(dx: -borderWidth, dy: -borderWidth)
+        }
+        .map {
+          CGRect(
+            origin: .init(x: $0.minX, y: $0.maxY - borderWidth),
+            size: .init(width: $0.width, height: borderWidth)
+          )
+        }
+    }
+  }
+
+  /// A table border selector that selects the inside vertical borders of a table, except for the first row.
+  public static var insideVerticalBordersExceptFirstRow: TableBorderSelector {
+    TableBorderSelector { tableBounds, borderWidth in
+      let rowCount = tableBounds.rowCount
+      guard rowCount > 1 else { return [] }
+      let firstRowBounds = tableBounds.bounds(forRow: 0)
+      return (0..<tableBounds.columnCount - 1)
+        .map {
+          tableBounds.bounds(forColumn: $0)
+            .insetBy(dx: -borderWidth, dy: -borderWidth)
+        }
+        .map {
+          CGRect(
+            origin: .init(x: $0.maxX - borderWidth, y: firstRowBounds.maxY),
+            size: .init(width: borderWidth, height: $0.height - firstRowBounds.maxY)
+          )
+        }
+    }
+  }
+
   /// A table border selector that selects the horizontal borders of a table.
   public static var horizontalBorders: TableBorderSelector {
     TableBorderSelector { tableBounds, borderWidth in

--- a/Sources/MarkdownUI/Views/Blocks/TableBorderView.swift
+++ b/Sources/MarkdownUI/Views/Blocks/TableBorderView.swift
@@ -11,15 +11,18 @@ struct TableBorderView: View {
 
   var body: some View {
     ZStack(alignment: .topLeading) {
-      let rectangles = self.tableBorderStyle.visibleBorders.rectangles(
-        self.tableBounds, self.borderWidth
-      )
-      ForEach(0..<rectangles.count, id: \.self) {
-        let rectangle = rectangles[$0]
-        Rectangle()
-          .strokeBorder(self.tableBorderStyle.color, style: self.tableBorderStyle.strokeStyle)
-          .offset(x: rectangle.minX, y: rectangle.minY)
-          .frame(width: rectangle.width, height: rectangle.height)
+      ForEach(0..<self.tableBorderStyle.borders.count, id: \.self) {
+        let border = self.tableBorderStyle.borders[$0]
+        let rectangles = border.visibleBorders.rectangles(
+          self.tableBounds, self.borderWidth
+        )
+        ForEach(0..<rectangles.count, id: \.self) {
+          let rectangle = rectangles[$0]
+          Rectangle()
+            .strokeBorder(border.color, style: self.tableBorderStyle.strokeStyle)
+            .offset(x: rectangle.minX, y: rectangle.minY)
+            .frame(width: rectangle.width, height: rectangle.height)
+        }
       }
     }
   }


### PR DESCRIPTION
It is now possible to pass multiple border styles to a table border style by passing an array with selectors and colors.
Also added new convinience table border selectors for selecting the first row or every other inside border.

Here's an example:

```swift
MarkdownUI.Theme()
.table { configuration in
        configuration.label
            .markdownTableBackgroundStyle(.init(background: { row, column in
                row == 0 ? .blue : .clear
            }))
            .markdownTableBorderStyle(
                TableBorderStyle([ // <----- It is now possible to pass an array here.
                    .init(visibleBorders: .insideBordersFirstRow, color: .green),
                    .init(visibleBorders: .insideBordersExceptFirstRow, color: .red)
                ], strokeStyle: .init(lineWidth: 1))
            )
            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
            .overlay(
                RoundedRectangle(cornerRadius: 10, style: .continuous)
                .strokeBorder(.black, lineWidth: 1)
            )
    }
    .tableCell { configuration in
        configuration.label
            .markdownTextStyle {
                if configuration.row == 0 {
                    ForegroundColor(.white)
                }
            }
            .padding(.vertical, 6)
            .padding(.horizontal, 6)
    }
```

![CleanShot 2024-06-11 at 23 47 58@2x](https://github.com/gonzalezreal/swift-markdown-ui/assets/177740/2e32c8d2-939f-4006-8110-817ebde182f7)
