### PR TITLE
feat: make the `Theme` type support sendablity 

### DIFF
--- a/Sources/MarkdownUI/Theme/Theme.swift
+++ b/Sources/MarkdownUI/Theme/Theme.swift
@@ -99,7 +99,7 @@ import SwiftUI
 ///   }
 ///   // More block styles...
 /// ```
-public struct Theme {
+public struct Theme: Sendable {
   /// The default text style.
   public var text: TextStyle = EmptyTextStyle()
 


### PR DESCRIPTION
The type must be sendable or it will be an error in Swift 6