### PR TITLE
custom-tableborderselector: custom-tableborderselector: Provide initi…

### DIFF
--- a/Sources/MarkdownUI/Views/Blocks/TableBorderSelector.swift
+++ b/Sources/MarkdownUI/Views/Blocks/TableBorderSelector.swift
@@ -4,7 +4,11 @@ import SwiftUI
 ///
 /// You use a table border selector to select the visible borders when creating a ``TableBorderStyle``.
 public struct TableBorderSelector {
-  var rectangles: (_ tableBounds: TableBounds, _ borderWidth: CGFloat) -> [CGRect]
+  public var rectangles: (_ tableBounds: TableBounds, _ borderWidth: CGFloat) -> [CGRect]
+
+  public init(rectangles: @escaping (_: TableBounds, _: CGFloat) -> [CGRect]) {
+     self.rectangles = rectangles
+   }
 }
 
 extension TableBorderSelector {

--- a/Sources/MarkdownUI/Views/Blocks/TableBounds.swift
+++ b/Sources/MarkdownUI/Views/Blocks/TableBounds.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
-struct TableBounds {
-  var rowCount: Int {
+public struct TableBounds {
+  public var rowCount: Int {
     self.rows.count
   }
 
-  var columnCount: Int {
+  public var columnCount: Int {
     self.columns.count
   }
 
-  let bounds: CGRect
+  public let bounds: CGRect
 
   private let rows: [(minY: CGFloat, height: CGFloat)]
   private let columns: [(minX: CGFloat, width: CGFloat)]
@@ -50,20 +50,20 @@ struct TableBounds {
     self.columns = columns
   }
 
-  func bounds(forRow row: Int, column: Int) -> CGRect {
+  public func bounds(forRow row: Int, column: Int) -> CGRect {
     CGRect(
       origin: .init(x: self.columns[column].minX, y: self.rows[row].minY),
       size: .init(width: self.columns[column].width, height: self.rows[row].height)
     )
   }
 
-  func bounds(forRow row: Int) -> CGRect {
+  public func bounds(forRow row: Int) -> CGRect {
     (0..<self.columnCount)
       .map { self.bounds(forRow: row, column: $0) }
       .reduce(.null, CGRectUnion)
   }
 
-  func bounds(forColumn column: Int) -> CGRect {
+  public func bounds(forColumn column: Int) -> CGRect {
     (0..<self.rowCount)
       .map { self.bounds(forRow: $0, column: column) }
       .reduce(.null, CGRectUnion)


### PR DESCRIPTION
Currently there is no way to create a custom `TableBorderSelector`, since the initialiser of `TableBorderSelector` and `TableBounds` aren't exposed. This PR changes those to `public`. With that we can now create custom `TableBorderSelector` like this one:
```swift
extension TableBorderSelector {
    public static var firstHorizontalBorder: TableBorderSelector {
        TableBorderSelector { tableBounds, borderWidth in
            guard tableBounds.rowCount >= 1 else { return [] }

            return [
                tableBounds.bounds(forRow: 0)
                    .insetBy(dx: -borderWidth, dy: -borderWidth)
            ]
                .map {
                    CGRect(
                        origin: .init(x: $0.minX, y: $0.maxY - borderWidth),
                        size: .init(width: $0.width, height: borderWidth)
                    )
                }
        }
    }
}
```