### PR TITLE
feat: address concurrency warnings arising from `Theme`

### DIFF
--- a/Sources/MarkdownUI/Theme/BlockStyle/BlockStyle.swift
+++ b/Sources/MarkdownUI/Theme/BlockStyle/BlockStyle.swift
@@ -37,8 +37,8 @@ import SwiftUI
 /// ```
 ///
 /// ![](CustomBlockquote)
-public struct BlockStyle<Configuration> {
-  private let body: (Configuration) -> AnyView
+public struct BlockStyle<Configuration> : Sendable {
+  private let body: @Sendable (Configuration) -> AnyView
 
   /// Creates a block style that customizes a block by applying the given body.
   /// - Parameter body: A view builder that returns the customized block.

--- a/Sources/MarkdownUI/Theme/TextStyle/Styles/FontSize.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/Styles/FontSize.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A text style that sets the font size.
 public struct FontSize: TextStyle {
-  private enum Size {
+  private enum Size: Sendable {
     case points(CGFloat)
     case relative(RelativeSize)
   }

--- a/Sources/MarkdownUI/Theme/TextStyle/TextStyle.swift
+++ b/Sources/MarkdownUI/Theme/TextStyle/TextStyle.swift
@@ -57,6 +57,6 @@ import SwiftUI
 /// ```
 ///
 /// ![](CustomBlockquote)
-public protocol TextStyle {
+public protocol TextStyle : Sendable {
   func _collectAttributes(in attributes: inout AttributeContainer)
 }

--- a/Sources/MarkdownUI/Utility/RelativeSize.swift
+++ b/Sources/MarkdownUI/Utility/RelativeSize.swift
@@ -21,8 +21,8 @@ import SwiftUI
 ///     FontSize(.em(2))
 ///   }
 /// ```
-public struct RelativeSize: Hashable {
-  enum Unit: Hashable {
+public struct RelativeSize: Hashable, Sendable {
+  enum Unit: Hashable, Sendable {
     case em
     case rem
   }


### PR DESCRIPTION
`Theme` was marked as `Sendable` in #351. There's nothing wrong with this per se, but sendability is not inferred for public types, a structure is only truely `Sendable` if all of its members are `Sendable`, and most of the members of `Theme` are not `Sendable`.

This patch address the sendability warnings for Theme's members that the compiler emits (regardless of `StrictConcurrency`).