### PR TITLE
chore: resolve isolation warnings related to `EnvironmentKey`

### DIFF
--- a/Sources/MarkdownUI/Views/Environment/Environment+BaseURL.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+BaseURL.swift
@@ -13,9 +13,9 @@ extension EnvironmentValues {
 }
 
 private struct BaseURLKey: EnvironmentKey {
-  static var defaultValue: URL? = nil
+  static var defaultValue: URL? { nil }
 }
 
 private struct ImageBaseURLKey: EnvironmentKey {
-  static var defaultValue: URL? = nil
+  static var defaultValue: URL? { nil }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+CodeSyntaxHighlighter.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+CodeSyntaxHighlighter.swift
@@ -23,5 +23,5 @@ extension EnvironmentValues {
 }
 
 private struct CodeSyntaxHighlighterKey: EnvironmentKey {
-  static let defaultValue: CodeSyntaxHighlighter = .plainText
+  static var defaultValue: CodeSyntaxHighlighter { .plainText }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+ImageProvider.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+ImageProvider.swift
@@ -20,5 +20,5 @@ extension EnvironmentValues {
 }
 
 private struct ImageProviderKey: EnvironmentKey {
-  static let defaultValue: AnyImageProvider = .init(.default)
+  static var defaultValue: AnyImageProvider { .init(.default) }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+InlineImageProvider.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+InlineImageProvider.swift
@@ -20,5 +20,5 @@ extension EnvironmentValues {
 }
 
 private struct InlineImageProviderKey: EnvironmentKey {
-  static let defaultValue: InlineImageProvider = .default
+  static var defaultValue: InlineImageProvider { .default }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+List.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+List.swift
@@ -13,9 +13,9 @@ extension EnvironmentValues {
 }
 
 private struct ListLevelKey: EnvironmentKey {
-  static var defaultValue = 0
+  static var defaultValue: Int { 0 }
 }
 
 private struct TightSpacingEnabledKey: EnvironmentKey {
-  static var defaultValue = false
+  static var defaultValue: Bool { false }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+SoftBreakMode.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+SoftBreakMode.swift
@@ -19,5 +19,5 @@ extension EnvironmentValues {
 }
 
 private struct SoftBreakModeKey: EnvironmentKey {
-  static let defaultValue: SoftBreak.Mode = .space
+  static var defaultValue: SoftBreak.Mode { .space }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+Table.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+Table.swift
@@ -37,9 +37,9 @@ extension EnvironmentValues {
 }
 
 private struct TableBorderStyleKey: EnvironmentKey {
-  static let defaultValue = TableBorderStyle(color: .secondary)
+  static var defaultValue: TableBorderStyle { TableBorderStyle(color: .secondary) }
 }
 
 private struct TableBackgroundStyleKey: EnvironmentKey {
-  static let defaultValue = TableBackgroundStyle.clear
+  static var defaultValue: TableBackgroundStyle { TableBackgroundStyle.clear }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+TextStyle.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+TextStyle.swift
@@ -51,5 +51,5 @@ extension EnvironmentValues {
 }
 
 private struct TextStyleKey: EnvironmentKey {
-  static let defaultValue: TextStyle = FontProperties()
+  static var defaultValue: TextStyle { FontProperties() }
 }

--- a/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
@@ -70,5 +70,5 @@ extension EnvironmentValues {
 }
 
 private struct ThemeKey: EnvironmentKey {
-  static let defaultValue: Theme = .basic
+  static var defaultValue: Theme { .basic }
 }


### PR DESCRIPTION
Most `EnvironmentKey` implementations produce this warning when strict concurrency warnings are enabled:
```
warning: static property 'defaultValue' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode
```

Switching from `var` to `let` resolves the issue.