### PR TITLE
chore: enable upcoming feature `InferSendableFromCaptures`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.10
 
 import PackageDescription
 
@@ -29,6 +29,9 @@ let package = Package(
         .product(name: "cmark-gfm", package: "swift-cmark"),
         .product(name: "cmark-gfm-extensions", package: "swift-cmark"),
         .product(name: "NetworkImage", package: "NetworkImage"),
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("InferSendableFromCaptures")
       ]
     ),
     .testTarget(

--- a/Sources/MarkdownUI/Utility/Deprecations.swift
+++ b/Sources/MarkdownUI/Utility/Deprecations.swift
@@ -55,7 +55,7 @@ extension View {
     _ keyPath: WritableKeyPath<Theme, BlockStyle<BlockConfiguration>>,
     @ViewBuilder body: @escaping (_ label: BlockConfiguration.Label) -> Body
   ) -> some View {
-    self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
+    self.environment((\EnvironmentValues.theme as WritableKeyPath).appending(path: keyPath), .init(body: body))
   }
 
   @available(
@@ -71,7 +71,7 @@ extension View {
     @ViewBuilder body: @escaping (_ label: BlockConfiguration.Label) -> Body
   ) -> some View {
     self.environment(
-      (\EnvironmentValues.theme).appending(path: keyPath),
+      (\EnvironmentValues.theme as WritableKeyPath).appending(path: keyPath),
       .init { configuration in
         body(.init(configuration.label))
       }

--- a/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
@@ -15,7 +15,7 @@ extension View {
     _ keyPath: WritableKeyPath<Theme, TextStyle>,
     @TextStyleBuilder textStyle: () -> S
   ) -> some View {
-    self.environment((\EnvironmentValues.theme).appending(path: keyPath), textStyle())
+    self.environment((\EnvironmentValues.theme as WritableKeyPath).appending(path: keyPath), textStyle())
   }
 
   /// Replaces a specific block style on the current ``Theme`` with a block style initialized with the given body closure.
@@ -26,7 +26,7 @@ extension View {
     _ keyPath: WritableKeyPath<Theme, BlockStyle<Void>>,
     @ViewBuilder body: @escaping () -> Body
   ) -> some View {
-    self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
+    self.environment((\EnvironmentValues.theme as WritableKeyPath).appending(path: keyPath), .init(body: body))
   }
 
   /// Replaces a specific block style on the current ``Theme`` with a block style initialized with the given body closure.
@@ -37,7 +37,7 @@ extension View {
     _ keyPath: WritableKeyPath<Theme, BlockStyle<Configuration>>,
     @ViewBuilder body: @escaping (_ configuration: Configuration) -> Body
   ) -> some View {
-    self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
+    self.environment((\EnvironmentValues.theme as WritableKeyPath).appending(path: keyPath), .init(body: body))
   }
 
   /// Replaces the current ``Theme`` task list marker with the given list marker.


### PR DESCRIPTION
A massive number of concurrency warnings concern `KeyPath` and issues with its sendability. Rather than chase these down make use of SE-0418, "Inferring Sendable for Methods and KeyPath Literals".

`swift-tools-version` is updated to 5.10, making the upcoming feature, `InferSendableFromCaptures` available. Once done, the compiler needs a little help assembling a correct `KeyPath` for `\Environment.theme`. A hint that it should be a `WritableKeyPath` is enough to get it on track.