### PR TITLE
Update syntax to be compliant with Swift 5.10 and later

### DIFF
--- a/Sources/MarkdownUI/Parser/MarkdownParser.swift
+++ b/Sources/MarkdownUI/Parser/MarkdownParser.swift
@@ -1,6 +1,11 @@
 import Foundation
+#if compiler(>=5.10)
+private import cmark_gfm
+private import cmark_gfm_extensions
+#else
 @_implementationOnly import cmark_gfm
 @_implementationOnly import cmark_gfm_extensions
+#endif
 
 extension Array where Element == BlockNode {
   init(markdown: String) {


### PR DESCRIPTION
Address a warning that shows up in Xcode 16.3